### PR TITLE
SAASMLOPS-805 Stopgap change to fix duplicate materialization of data

### DIFF
--- a/sdk/python/feast/infra/materialization/contrib/bytewax/Dockerfile
+++ b/sdk/python/feast/infra/materialization/contrib/bytewax/Dockerfile
@@ -25,5 +25,5 @@ COPY README.md README.md
 # git dir to infer the version of feast we're installing.
 # https://github.com/pypa/setuptools_scm#usage-from-docker
 # I think it also assumes that this dockerfile is being built from the root of the directory.
-RUN --mount=source=.git,target=.git,type=bind pip3 install --no-cache-dir -e '.[aws,gcp,bytewax]'
+RUN --mount=source=.git,target=.git,type=bind pip3 install --no-cache-dir '.[aws,gcp,bytewax,snowflake]'
 

--- a/sdk/python/feast/infra/materialization/contrib/bytewax/bytewax_materialization_dataflow.py
+++ b/sdk/python/feast/infra/materialization/contrib/bytewax/bytewax_materialization_dataflow.py
@@ -30,6 +30,7 @@ class BytewaxMaterializationDataflow:
 
     def process_path(self, path):
         fs = s3fs.S3FileSystem()
+        print(f"Processing path {path}")
         dataset = pq.ParquetDataset(path, filesystem=fs, use_legacy_dataset=False)
         batches = []
         for fragment in dataset.fragments:

--- a/sdk/python/feast/infra/materialization/contrib/bytewax/bytewax_materialization_engine.py
+++ b/sdk/python/feast/infra/materialization/contrib/bytewax/bytewax_materialization_engine.py
@@ -197,9 +197,12 @@ class BytewaxMaterializationEngine(BatchMaterializationEngine):
                     logger.info(f"{feature_view.name} materialization still running...")
                     sleep(30)
                 logger.info(f"{feature_view.name} materialization complete with status {job.status()}")
-            except (KeyboardInterrupt, BaseException) as e:
+            except BaseException as e:
                 logger.info(f"Killing job {job.job_id()}")
-                self.batch_v1.delete_namespaced_job(job.job_id(), self.namespace)
+                try:
+                    self.batch_v1.delete_namespaced_job(job.job_id(), self.namespace)
+                except ApiException as de:
+                    logger.warning(f"Could not delete job due to API Error: {ae.body}")
                 raise e
             self._print_pod_logs(job.job_id(), feature_view)
         return job
@@ -321,8 +324,8 @@ class BytewaxMaterializationEngine(BatchMaterializationEngine):
             "spec": {
                 "ttlSecondsAfterFinished": 3600,
                 "backoffLimit": self.batch_engine_config.retry_limit,
-                "completions": pods,
-                "parallelism": min(pods, self.batch_engine_config.max_parallelism),
+                "completions": 1,
+                "parallelism": 1,
                 "completionMode": "Indexed",
                 "template": {
                     "metadata": {

--- a/sdk/python/feast/infra/materialization/contrib/bytewax/bytewax_materialization_engine.py
+++ b/sdk/python/feast/infra/materialization/contrib/bytewax/bytewax_materialization_engine.py
@@ -290,7 +290,7 @@ class BytewaxMaterializationEngine(BatchMaterializationEngine):
             },
             {
                 "name": "BYTEWAX_REPLICAS",
-                "value": f"{pods}",
+                "value": "1",
             },
             {
                 "name": "BYTEWAX_KEEP_CONTAINER_ALIVE",
@@ -342,7 +342,7 @@ class BytewaxMaterializationEngine(BatchMaterializationEngine):
                                 "env": [
                                     {
                                         "name": "BYTEWAX_REPLICAS",
-                                        "value": f"{pods}",
+                                        "value": "1",
                                     }
                                 ],
                                 "image": "busybox",


### PR DESCRIPTION
Bytewax materializes ALL THE DATA on ALL THE PODS, which causes each pod to run forever, and write tons of duplicate data.  This fix changes that temporarily by running materialization in a single pod