### PR TITLE
SAASMLOPS-833 add configurable job timeout

### DIFF
--- a/sdk/python/feast/infra/materialization/contrib/bytewax/bytewax_materialization_engine.py
+++ b/sdk/python/feast/infra/materialization/contrib/bytewax/bytewax_materialization_engine.py
@@ -84,6 +84,8 @@ class BytewaxMaterializationEngineConfig(FeastConfigBaseModel):
     retry_limit: int = 2
     """ (optional) Maximum number of times to retry a materialization worker pod"""
 
+    active_deadline_seconds: int = 86400
+    """ (optional) Maximum amount of time a materialization job is allowed to run"""
 
 class BytewaxMaterializationEngine(BatchMaterializationEngine):
     def __init__(
@@ -324,8 +326,10 @@ class BytewaxMaterializationEngine(BatchMaterializationEngine):
             "spec": {
                 "ttlSecondsAfterFinished": 3600,
                 "backoffLimit": self.batch_engine_config.retry_limit,
+
                 "completions": pods,
                 "parallelism": min(pods, self.batch_engine_config.max_parallelism),
+                "activeDeadlineSeconds": self.batch_engine_config.active_deadline_seconds,
                 "completionMode": "Indexed",
                 "template": {
                     "metadata": {

--- a/sdk/python/feast/infra/materialization/contrib/bytewax/bytewax_materialization_engine.py
+++ b/sdk/python/feast/infra/materialization/contrib/bytewax/bytewax_materialization_engine.py
@@ -326,7 +326,6 @@ class BytewaxMaterializationEngine(BatchMaterializationEngine):
             "spec": {
                 "ttlSecondsAfterFinished": 3600,
                 "backoffLimit": self.batch_engine_config.retry_limit,
-
                 "completions": pods,
                 "parallelism": min(pods, self.batch_engine_config.max_parallelism),
                 "activeDeadlineSeconds": self.batch_engine_config.active_deadline_seconds,


### PR DESCRIPTION
Required to fix infinitely running jobs caused by pod deletions during long runs

Tested by setting 30 second limit on job and observing that the job failed